### PR TITLE
Fixed UAWUnitType isn't available in PayloadSource.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
     // Other Libs
     implementation 'com.github.Zelaux.GasLibrary:core:a55948ec113566f3a3a4a1f1508d6f9f07161157'
+    compileOnly 'com.sun.istack:istack-commons-runtime:4.1.1'
 }
 
 task jarAndroid {

--- a/src/UAW/content/UAWUnitTypes.java
+++ b/src/UAW/content/UAWUnitTypes.java
@@ -14,7 +14,7 @@ import arc.graphics.Color;
 import arc.math.Mathf;
 import arc.struct.*;
 import arc.struct.ObjectMap.Entry;
-import com.sun.istack.internal.NotNull;
+import com.sun.istack.NotNull;
 import mindustry.content.*;
 import mindustry.ctype.ContentList;
 import mindustry.entities.Effect;

--- a/src/UAW/content/UAWUnitTypes.java
+++ b/src/UAW/content/UAWUnitTypes.java
@@ -14,6 +14,7 @@ import arc.graphics.Color;
 import arc.math.Mathf;
 import arc.struct.*;
 import arc.struct.ObjectMap.Entry;
+import com.sun.istack.internal.NotNull;
 import mindustry.content.*;
 import mindustry.ctype.ContentList;
 import mindustry.entities.Effect;
@@ -24,6 +25,7 @@ import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.type.ammo.ItemAmmoType;
 import mindustry.type.weapons.PointDefenseWeapon;
+import mindustry.world.blocks.payloads.PayloadSource;
 import mindustry.world.meta.BlockFlag;
 
 import static UAW.Vars.*;
@@ -85,6 +87,10 @@ public class UAWUnitTypes implements ContentList {
 		}
 	}
 
+	private static void setupPayloadSource(){
+		registerPayloadSource(UAWUnitType.class);
+	}
+
 	/**
 	 * Retrieves the class ID for a certain entity type.
 	 *
@@ -97,6 +103,7 @@ public class UAWUnitTypes implements ContentList {
 	@Override
 	public void load() {
 		setupID();
+		setupPayloadSource();
 
 		aglovale = new UAWUnitType("aglovale") {{
 			health = 500;
@@ -1370,5 +1377,19 @@ public class UAWUnitTypes implements ContentList {
 				}};
 			}});
 		}};
+	}
+
+	public static <T extends UnitType>
+	void registerPayloadSource(@NotNull Class<T> clz) {
+		var source = (PayloadSource) Blocks.payloadSource;
+		source.config((Class<UnitType>) clz,
+				(PayloadSource.PayloadSourceBuild build, UnitType type) -> {
+					if (source.canProduce(type) && build.unit != type) {
+						build.unit = type;
+						build.block = null;
+						build.payload = null;
+						build.scl = 0f;
+					}
+				});
 	}
 }


### PR DESCRIPTION
1. It should be noted it's awful that vanilla used anonymous class to declare every content.
2. Block#configure will detect whether this class is anonymous then use its super class.
3. If you want to hide those units in your mod in payload source, just close this pull request.
4. I can't build and test my code because of https://github.com/Anuken/MindustryJavaModTemplate/issues/12, please test it on your own.